### PR TITLE
okHttpClient 单例化

### DIFF
--- a/JetpackMvvm/src/main/java/me/hgj/jetpackmvvm/network/BaseNetworkApi.kt
+++ b/JetpackMvvm/src/main/java/me/hgj/jetpackmvvm/network/BaseNetworkApi.kt
@@ -33,12 +33,19 @@ abstract class BaseNetworkApi {
     /**
      * 配置http
      */
-    private val okHttpClient: OkHttpClient
-        get() {
-            var builder = RetrofitUrlManager.getInstance().with(OkHttpClient.Builder())
-            builder = setHttpClientBuilder(builder)
-            return builder.build()
-        }
+//     private val okHttpClient: OkHttpClient
+//         get() {
+//             var builder = RetrofitUrlManager.getInstance().with(OkHttpClient.Builder())
+//             builder = setHttpClientBuilder(builder)
+//             return builder.build()
+//         }
+    
+        private val okHttpClient by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        var builder = RetrofitUrlManager.getInstance().with(OkHttpClient.Builder())
+        builder = setHttpClientBuilder(builder)
+        builder.build()
+    }
+    
 }
 
 


### PR DESCRIPTION
在有些项目中, 网络请求可能不止一个apiService，很有可能是多个api，如UserApiService, OrderApiService,BuyCartApiService,再Api单例化的时候，okHttpClient 会创建多个对象，影响性能。因此okHttpClient 需要单例化。当然在此项目中只有一个apiService，并没有此问题。